### PR TITLE
Added update instructions and composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ As an alternative solution (if you are using default Winter installation with de
 git clone https://github.com/skripteria/wn-snowflake-plugin.git ./plugins/skripteria/snowflake && php artisan winter:up
 ```
 
+### Updating existing installation
+
+If you have previously installed Snowflake plugin with GitHub installation method described above and want to update plugin with the latest changes then you can execute the following commands from the Winter project root:
+
+```sh
+cd ./plugins/skripteria/snowflake
+git pull origin main
+```
+
+It is also recommended to execute `winter:up` commmand after the previous steps to apply any new database migrations introduced with the latest changes:
+
+```sh
+php artisan winter:up
+```
+
 ## Why a new "CMS" within a CMS at all?
 
 In real life there are at least 4 different user types that all need to be taken care of the same time:

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "skripteria/wn-snowflake-plugin",
+    "type": "winter-plugin",
+    "description": "Snowflake plugin is dynamic content manager for Winter CMS",
+    "homepage": "https://github.com/skripteria/wn-snowflake-plugin",
+    "keywords": ["wintercms", "snowflake", "plugin", "cms"],
+    "authors": [
+        {
+            "name": "skripteria",
+            "homepage": "https://github.com/skripteria",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/skripteria/wn-snowflake-plugin/issues",
+        "source": "https://github.com/skripteria/wn-snowflake-plugin"
+    },
+    "require": {
+        "php": ">=7.0",
+        "composer/installers": "~1.0"
+    },
+    "extra": {
+        "installer-name": "snowflake"
+    }
+}


### PR DESCRIPTION
This pull request adds information about how to update Snowflake plugin while it's in the development stage and was previously installed installed with GitHub installation method.

I also added the basic version of `composer.json` file so maybe latter plugin can be placed also on Packagist site and installed/updated via composer more easier.