### PR TITLE
Layout improvements; small clean-ups in yaml files

### DIFF
--- a/models/element/columns.yaml
+++ b/models/element/columns.yaml
@@ -15,6 +15,3 @@ columns:
         label: Description
         type: text
         searchable: true
-
-
-

--- a/models/element/fields.yaml
+++ b/models/element/fields.yaml
@@ -3,20 +3,19 @@
 # ===================================
 
 fields:
-    type:
-        label: Type
-        type: relation
-        nameFrom: name
-        span: left
-        readOnly: true
     cms_key:
         label: Snowflake Key
         type: text
         span: left
+        readOnly: true
+    type:
+        label: Type
+        type: relation
+        nameFrom: name
+        span: right
         readOnly: true
     desc:
         label: Description
         type: text
         span: full
         readonly: true
-    

--- a/models/element/fields_markdown.yaml
+++ b/models/element/fields_markdown.yaml
@@ -3,7 +3,6 @@
 # ===================================
 
 fields:
-
     content_markdown:
         type: markdown
         hidden: true
@@ -16,7 +15,6 @@ fields:
         hidden: true
     content:
         type: text
-
     type:
         label: Type
         type: relation


### PR DESCRIPTION
This is a very small pull request in which the most changes are made in `models/element/fields.yaml` file - I reordered field order and optimized space in content block editing view. Preview of changes can be seen in this image: 

![2021-12-11_12-30](https://user-images.githubusercontent.com/626982/145673460-af41cbdf-ae6c-4edc-b11a-931c33ef3fff.png)

As the first two fields of the form/view are readOnly and also they contain small amount of information - only key name and type then I think it's a good idea to make them both in the same row so there is more space for other fields added after them.

The field order was changed because in this case it would be more important to show Snowflake Key name on the left, at the beginning, rather than the type. Also in the column lists etc. the Snowflake Key is usually used showed before the type value.

Some blank spaces and lines were removed in other `.yaml` files but that's just a clean-up.